### PR TITLE
feat: Adds support for YAML-based basic agents

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,6 +112,11 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf.version}</version>

--- a/core/src/main/java/com/google/adk/agents/BaseAgent.java
+++ b/core/src/main/java/com/google/adk/agents/BaseAgent.java
@@ -23,6 +23,7 @@ import com.google.adk.agents.Callbacks.AfterAgentCallback;
 import com.google.adk.agents.Callbacks.BeforeAgentCallback;
 import com.google.adk.events.Event;
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.DoNotCall;
 import com.google.genai.types.Content;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -359,4 +360,19 @@ public abstract class BaseAgent {
    * @return stream of agent-generated events.
    */
   protected abstract Flowable<Event> runLiveImpl(InvocationContext invocationContext);
+
+  /**
+   * Creates a new agent instance from a configuration object.
+   *
+   * @param config Agent configuration.
+   * @param configAbsPath Absolute path to the configuration file.
+   * @return new agent instance.
+   */
+  // TODO: Makes `BaseAgent.fromConfig` a final method and let sub-class to optionally override
+  // `_parse_config` to update kwargs if needed.
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
+  public static BaseAgent fromConfig(BaseAgentConfig config, String configAbsPath) {
+    throw new UnsupportedOperationException(
+        "BaseAgent is abstract. Override fromConfig in concrete subclasses.");
+  }
 }

--- a/core/src/main/java/com/google/adk/agents/BaseAgentConfig.java
+++ b/core/src/main/java/com/google/adk/agents/BaseAgentConfig.java
@@ -26,9 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class BaseAgentConfig {
   private String name;
   private String description = "";
-  // TODO: Add agentClassType enum to the config and handle different values from user
-  // input.e.g.LLM_AGENT, LlmAgent
-  private String agentClass = null;
+  private String agentClass;
 
   @JsonProperty(value = "name", required = true)
   public String name() {

--- a/core/src/main/java/com/google/adk/agents/BaseAgentConfig.java
+++ b/core/src/main/java/com/google/adk/agents/BaseAgentConfig.java
@@ -21,11 +21,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Base configuration for all agents.
  *
- * <p>workInProgress: Config agent features are not yet ready for public use.
+ * <p>TODO: Config agent features are not yet ready for public use.
  */
 public class BaseAgentConfig {
   private String name;
   private String description = "";
+  // TODO: Add agentClassType enum to the config and handle different values from user
+  // input.e.g.LLM_AGENT, LlmAgent
+  private String agentClass = null;
 
   @JsonProperty(value = "name", required = true)
   public String name() {
@@ -43,5 +46,14 @@ public class BaseAgentConfig {
 
   public void setDescription(String description) {
     this.description = description;
+  }
+
+  @JsonProperty("agent_class")
+  public String agentClass() {
+    return agentClass;
+  }
+
+  public void setAgentClass(String agentClass) {
+    this.agentClass = agentClass;
   }
 }

--- a/core/src/main/java/com/google/adk/agents/ConfigAgentUtils.java
+++ b/core/src/main/java/com/google/adk/agents/ConfigAgentUtils.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.agents;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for loading agent configurations from YAML files.
+ *
+ * <p>TODO: Config agent features are not yet ready for public use.
+ */
+public final class ConfigAgentUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ConfigAgentUtils.class);
+
+  private ConfigAgentUtils() {}
+
+  /**
+   * Load agent from a YAML config file path.
+   *
+   * @param configPath the path to a YAML config file
+   * @return the created agent instance as a {@link BaseAgent}
+   * @throws ConfigurationException if loading fails
+   */
+  public static BaseAgent fromConfig(String configPath) throws ConfigurationException {
+
+    File configFile = new File(configPath);
+    if (!configFile.exists()) {
+      logger.error("Config file not found: {}", configPath);
+      throw new ConfigurationException("Config file not found: " + configPath);
+    }
+
+    String absolutePath = configFile.getAbsolutePath();
+
+    try {
+      // Load the base config to determine the agent class
+      BaseAgentConfig baseConfig = loadConfigAsType(absolutePath, BaseAgentConfig.class);
+      Class<? extends BaseAgent> agentClass = resolveAgentClass(baseConfig.agentClass());
+
+      // Load the config file with the specific config class
+      Class<? extends BaseAgentConfig> configClass = getConfigClassForAgent(agentClass);
+      BaseAgentConfig config = loadConfigAsType(absolutePath, configClass);
+      logger.info("agentClass value = '{}'", config.agentClass());
+
+      // Use reflection to call the fromConfig method with the correct types
+      java.lang.reflect.Method fromConfigMethod =
+          agentClass.getDeclaredMethod("fromConfig", configClass, String.class);
+      return (BaseAgent) fromConfigMethod.invoke(null, config, absolutePath);
+
+    } catch (ConfigurationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ConfigurationException("Failed to create agent from config: " + configPath, e);
+    }
+  }
+
+  /**
+   * Load configuration from a YAML file path as a specific type.
+   *
+   * @param configPath the absolute path to the config file
+   * @param configClass the class to deserialize the config into
+   * @return the loaded configuration
+   * @throws ConfigurationException if loading fails
+   */
+  private static <T extends BaseAgentConfig> T loadConfigAsType(
+      String configPath, Class<T> configClass) throws ConfigurationException {
+    try (InputStream inputStream = new FileInputStream(configPath)) {
+      ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+      mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      return mapper.readValue(inputStream, configClass);
+    } catch (IOException e) {
+      throw new ConfigurationException("Failed to load or parse config file: " + configPath, e);
+    }
+  }
+
+  /**
+   * Resolves the agent class based on the agent class name from the configuration.
+   *
+   * @param agentClassName the name of the agent class from the config
+   * @return the corresponding agent class
+   * @throws ConfigurationException if the agent class is not supported
+   */
+  private static Class<? extends BaseAgent> resolveAgentClass(String agentClassName)
+      throws ConfigurationException {
+    // If no agent_class is specified in the yaml file, it will default to LlmAgent.
+    if (isNullOrEmpty(agentClassName) || agentClassName.equals("LlmAgent")) {
+      return LlmAgent.class;
+    }
+
+    // TODO: Support more agent classes
+    // Example for future extensions:
+    // if (agentClassName.equals("CustomAgent")) {
+    //   return CustomAgent.class;
+    // }
+
+    throw new ConfigurationException(
+        "agentClass '"
+            + agentClassName
+            + "' is not supported. It must be a subclass of BaseAgent.");
+  }
+
+  /**
+   * Maps agent classes to their corresponding config classes.
+   *
+   * @param agentClass the agent class
+   * @return the corresponding config class
+   */
+  private static Class<? extends BaseAgentConfig> getConfigClassForAgent(
+      Class<? extends BaseAgent> agentClass) {
+
+    if (agentClass == LlmAgent.class) {
+      return LlmAgentConfig.class;
+    }
+
+    // TODO: Add more agent class to config class mappings as needed
+    // Example:
+    // if (agentClass == CustomAgent.class) {
+    //   return CustomAgentConfig.class;
+    // }
+
+    // Default fallback to BaseAgentConfig
+    return BaseAgentConfig.class;
+  }
+
+  /** Exception thrown when configuration is invalid. */
+  public static class ConfigurationException extends Exception {
+    public ConfigurationException(String message) {
+      super(message);
+    }
+
+    public ConfigurationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/core/src/main/java/com/google/adk/agents/LlmAgentConfig.java
+++ b/core/src/main/java/com/google/adk/agents/LlmAgentConfig.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Configuration for LlmAgent.
  *
- * <p>workInProgress: Config agent features are not yet ready for public use.
+ * <p>TODO: Config agent features are not yet ready for public use.
  */
 public class LlmAgentConfig extends BaseAgentConfig {
   private String model;
@@ -29,6 +29,11 @@ public class LlmAgentConfig extends BaseAgentConfig {
   private Boolean disallowTransferToParent;
   private Boolean disallowTransferToPeers;
   private String outputKey;
+
+  public LlmAgentConfig() {
+    super();
+    setAgentClass("LlmAgent");
+  }
 
   // Non-standard accessors with JsonProperty annotations
   @JsonProperty("model")

--- a/core/src/test/java/com/google/adk/agents/ConfigAgentUtilsTest.java
+++ b/core/src/test/java/com/google/adk/agents/ConfigAgentUtilsTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.agents;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.adk.agents.ConfigAgentUtils.ConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ConfigAgentUtils}. */
+@RunWith(JUnit4.class)
+public final class ConfigAgentUtilsTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void fromConfig_nonExistentFile_throwsException() {
+    String nonExistentPath = new File(tempFolder.getRoot(), "nonexistent.yaml").getAbsolutePath();
+    ConfigurationException exception =
+        assertThrows(
+            ConfigurationException.class, () -> ConfigAgentUtils.fromConfig(nonExistentPath));
+    assertThat(exception).hasMessageThat().isEqualTo("Config file not found: " + nonExistentPath);
+  }
+
+  @Test
+  public void fromConfig_invalidYaml_throwsException() throws IOException {
+    File configFile = tempFolder.newFile("invalid.yaml");
+    Files.writeString(configFile.toPath(), "name: test\n  description: invalid indent");
+    String configPath = configFile.getAbsolutePath();
+
+    ConfigurationException exception =
+        assertThrows(ConfigurationException.class, () -> ConfigAgentUtils.fromConfig(configPath));
+    assertThat(exception).hasMessageThat().startsWith("Failed to load or parse config file:");
+  }
+
+  @Test
+  public void fromConfig_validYamlLlmAgent_attemptsToCreateLlmAgent()
+      throws IOException, ConfigurationException {
+    File configFile = tempFolder.newFile("valid.yaml");
+    Files.writeString(
+        configFile.toPath(),
+        "name: testAgent\n"
+            + "description: A test agent\n"
+            + "instruction: test instruction\n"
+            + "agent_class: LlmAgent\n");
+    String configPath = configFile.getAbsolutePath();
+    BaseAgent agent = ConfigAgentUtils.fromConfig(configPath);
+    assertThat(agent).isNotNull();
+    assertThat(agent).isInstanceOf(LlmAgent.class);
+  }
+
+  @Test
+  public void fromConfig_customAgentClass_throwsUnsupportedException() throws IOException {
+    File configFile = tempFolder.newFile("custom.yaml");
+    String customAgentClass = "com.example.CustomAgent";
+    Files.writeString(
+        configFile.toPath(),
+        String.format(
+            "name: customAgent\n" + "description: A custom agent\n" + "agent_class: %s \n",
+            customAgentClass));
+    String configPath = configFile.getAbsolutePath();
+    ConfigurationException exception =
+        assertThrows(ConfigurationException.class, () -> ConfigAgentUtils.fromConfig(configPath));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "agentClass '"
+                + customAgentClass
+                + "' is not supported. It must be a subclass of BaseAgent.");
+  }
+
+  @Test
+  public void fromConfig_baseAgentClass_throwsUnsupportedException() throws IOException {
+    File configFile = tempFolder.newFile("custom.yaml");
+    String customAgentClass = "BaseAgent";
+    Files.writeString(
+        configFile.toPath(),
+        "name: customAgent\n" + "description: A custom agent\n" + "agent_class: BaseAgent \n");
+    String configPath = configFile.getAbsolutePath();
+    ConfigurationException exception =
+        assertThrows(ConfigurationException.class, () -> ConfigAgentUtils.fromConfig(configPath));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "agentClass '"
+                + customAgentClass
+                + "' is not supported. It must be a subclass of BaseAgent.");
+  }
+
+  @Test
+  public void fromConfig_emptyAgentClass_defaultsToLlmAgent()
+      throws IOException, ConfigurationException {
+    File configFile = tempFolder.newFile("empty_class.yaml");
+    Files.writeString(
+        configFile.toPath(),
+        "name: emptyClassAgent\n"
+            + "description: Agent with empty class\n"
+            + "instruction: test instruction\n"
+            + "agent_class: \"\"\n");
+    String configPath = configFile.getAbsolutePath();
+    BaseAgent agent = ConfigAgentUtils.fromConfig(configPath);
+    assertThat(agent).isNotNull();
+    assertThat(agent).isInstanceOf(LlmAgent.class);
+  }
+
+  @Test
+  public void fromConfig_withoutAgentClass_defaultsToLlmAgent()
+      throws IOException, ConfigurationException {
+    File configFile = tempFolder.newFile("empty_class.yaml");
+    Files.writeString(
+        configFile.toPath(),
+        "name: emptyClassAgent\n"
+            + "description: Agent with empty class\n"
+            + "instruction: test instruction\n");
+    String configPath = configFile.getAbsolutePath();
+    BaseAgent agent = ConfigAgentUtils.fromConfig(configPath);
+    assertThat(agent).isNotNull();
+    assertThat(agent).isInstanceOf(LlmAgent.class);
+  }
+
+  @Test
+  public void fromConfig_yamlWithExtraFields_ignoresUnknownProperties()
+      throws IOException, ConfigurationException {
+    File configFile = tempFolder.newFile("extra_fields.yaml");
+    Files.writeString(
+        configFile.toPath(),
+        "name: flexibleAgent\n"
+            + "description: Agent with extra fields\n"
+            + "instruction: test instruction\n"
+            + "agent_class: LlmAgent\n"
+            + "unknown_field: some_value\n"
+            + "another_unknown: 123\n"
+            + "nested_unknown:\n"
+            + "  key: value\n");
+    String configPath = configFile.getAbsolutePath();
+
+    BaseAgent agent = ConfigAgentUtils.fromConfig(configPath);
+
+    assertThat(agent).isNotNull();
+    assertThat(agent).isInstanceOf(LlmAgent.class);
+    assertThat(agent.name()).isEqualTo("flexibleAgent");
+    assertThat(agent.description()).isEqualTo("Agent with extra fields");
+  }
+
+  @Test
+  public void fromConfig_missingRequiredFields_throwsException() throws IOException {
+    File configFile = tempFolder.newFile("incomplete.yaml");
+    Files.writeString(
+        configFile.toPath(),
+        "description: Agent missing required fields\n" + "agent_class: LlmAgent\n");
+    String configPath = configFile.getAbsolutePath();
+
+    ConfigurationException exception =
+        assertThrows(ConfigurationException.class, () -> ConfigAgentUtils.fromConfig(configPath));
+
+    assertThat(exception).hasMessageThat().contains("Failed to create agent from config");
+    assertThat(exception.getCause()).isNotNull();
+  }
+}

--- a/core/src/test/java/com/google/adk/agents/LlmAgentTest.java
+++ b/core/src/test/java/com/google/adk/agents/LlmAgentTest.java
@@ -27,7 +27,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.adk.events.Event;
+import com.google.adk.models.LlmRegistry;
 import com.google.adk.models.LlmResponse;
+import com.google.adk.models.Model;
 import com.google.adk.testing.TestLlm;
 import com.google.adk.testing.TestUtils.EchoTool;
 import com.google.adk.tools.BaseTool;
@@ -288,5 +290,17 @@ public final class LlmAgentTest {
         agent.canonicalGlobalInstruction(invocationContext).blockingGet().getKey();
 
     assertThat(canonicalInstruction).isEqualTo(instruction + invocationContext.invocationId());
+  }
+
+  @Test
+  public void resolveModel_withModelName_resolvesFromRegistry() {
+    String modelName = "test-model";
+    TestLlm testLlm = createTestLlm(LlmResponse.builder().build());
+    LlmRegistry.registerLlm(modelName, (name) -> testLlm);
+    LlmAgent agent = createTestAgentBuilder(testLlm).model(modelName).build();
+    Model resolvedModel = agent.resolvedModel();
+
+    assertThat(resolvedModel.modelName()).hasValue(modelName);
+    assertThat(resolvedModel.model()).hasValue(testLlm);
   }
 }

--- a/dev/src/main/java/com/google/adk/web/AdkWebServer.java
+++ b/dev/src/main/java/com/google/adk/web/AdkWebServer.java
@@ -87,6 +87,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -127,6 +128,9 @@ public class AdkWebServer implements WebMvcConfigurer {
   @Value("${adk.web.ui.dir:#{null}}")
   private String webUiDir;
 
+  @Value("${adk.agent.hotReloadingEnabled:true}")
+  private boolean hotReloadingEnabled;
+
   @Bean
   public BaseSessionService sessionService() {
     // TODO: Add logic to select service based on config (e.g., DB URL)
@@ -148,18 +152,38 @@ public class AdkWebServer implements WebMvcConfigurer {
 
   @Bean("loadedAgentRegistry")
   public Map<String, BaseAgent> loadedAgentRegistry(
-      AgentCompilerLoader loader, AgentLoadingProperties props) {
+      AgentLoadingProperties props, RunnerService runnerService) {
+    Map<String, BaseAgent> agents = new ConcurrentHashMap<>();
+
     if (props.getSourceDir() == null || props.getSourceDir().isEmpty()) {
       log.info("adk.agents.source-dir not set. Initializing with an empty agent registry.");
-      return Collections.emptyMap();
+      return agents;
     }
+
     try {
-      Map<String, BaseAgent> agents = loader.loadAgents();
-      log.info("Loaded {} dynamic agent(s): {}", agents.size(), agents.keySet());
+      // Create and use compiler loader
+      AgentCompilerLoader compilerLoader = new AgentCompilerLoader(props);
+      Map<String, BaseAgent> compiledAgents = compilerLoader.loadAgents();
+      agents.putAll(compiledAgents);
+      log.info("Loaded {} compiled agents: {}", compiledAgents.size(), compiledAgents.keySet());
+
+      // Create and use YAML hot loader
+      AgentYamlHotLoader yamlLoader =
+          new AgentYamlHotLoader(props, agents, runnerService, hotReloadingEnabled);
+      Map<String, BaseAgent> yamlAgents = yamlLoader.loadAgents();
+      agents.putAll(yamlAgents);
+      log.info("Loaded {} YAML agents: {}", yamlAgents.size(), yamlAgents.keySet());
+
+      // Start hot-reloading
+      if (yamlLoader.supportsHotReloading()) {
+        yamlLoader.start();
+        log.info("Started hot-reloading for YAML agents");
+      }
+
       return agents;
     } catch (IOException e) {
-      log.error("Failed to load dynamic agents", e);
-      return Collections.emptyMap();
+      log.error("Failed to load agents", e);
+      return agents;
     }
   }
 
@@ -180,7 +204,7 @@ public class AdkWebServer implements WebMvcConfigurer {
 
     @Autowired
     public RunnerService(
-        @Qualifier("loadedAgentRegistry") Map<String, BaseAgent> agentRegistry,
+        @Lazy @Qualifier("loadedAgentRegistry") Map<String, BaseAgent> agentRegistry,
         BaseArtifactService artifactService,
         BaseSessionService sessionService) {
       this.agentRegistry = agentRegistry;
@@ -214,6 +238,16 @@ public class AdkWebServer implements WebMvcConfigurer {
                 agent.name());
             return new Runner(agent, appName, this.artifactService, this.sessionService);
           });
+    }
+
+    /** Called by hot loader when agents are updated */
+    public void onAgentUpdated(String agentName) {
+      Runner removed = runnerCache.remove(agentName);
+      if (removed != null) {
+        log.info("Cleared cached Runner for updated agent: {}", agentName);
+      } else {
+        log.debug("No cached Runner found for agent: {}", agentName);
+      }
     }
   }
 

--- a/dev/src/main/java/com/google/adk/web/AgentCompilerLoader.java
+++ b/dev/src/main/java/com/google/adk/web/AgentCompilerLoader.java
@@ -54,11 +54,21 @@ import org.springframework.stereotype.Service;
  * subdirectories or as individual {@code .java} files.
  */
 @Service
-public class AgentCompilerLoader {
+public class AgentCompilerLoader implements AgentLoader {
   private static final Logger logger = LoggerFactory.getLogger(AgentCompilerLoader.class);
   private final AgentLoadingProperties properties;
   private Path compiledAgentsOutputDir;
   private final String adkCoreJarPathForCompilation;
+
+  @Override
+  public String getLoaderType() {
+    return "Compiled Java Agents";
+  }
+
+  @Override
+  public boolean supportsHotReloading() {
+    return false;
+  }
 
   /**
    * Initializes the loader with agent configuration and proactively attempts to locate the ADK core

--- a/dev/src/main/java/com/google/adk/web/AgentLoader.java
+++ b/dev/src/main/java/com/google/adk/web/AgentLoader.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.web;
+
+import com.google.adk.agents.BaseAgent;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Interface for loading agents into a registry. Implementations can handle different types of agent
+ * sources (compiled Java classes, YAML configurations, etc.) and loading strategies (one-time
+ * loading, hot-reloading, etc.).
+ */
+public interface AgentLoader {
+
+  /**
+   * Loads agents and returns them as a map. This method performs a one-time loading operation and
+   * returns all discovered agents.
+   *
+   * @return A map of agent names to their BaseAgent instances
+   * @throws IOException if there's an error during loading
+   */
+  Map<String, BaseAgent> loadAgents() throws IOException;
+
+  /**
+   * Starts any ongoing monitoring or hot-reloading functionality. For loaders that support
+   * continuous monitoring (like hot-reloading), this method should be called to activate the
+   * monitoring process.
+   *
+   * @throws IOException if there's an error starting the monitoring
+   */
+  default void start() throws IOException {
+    // Default implementation does nothing - for loaders that don't support continuous monitoring
+  }
+
+  /**
+   * Stops any ongoing monitoring or hot-reloading functionality and cleans up resources. Should be
+   * called when the loader is no longer needed.
+   */
+  default void stop() {
+    // Default implementation does nothing - for loaders that don't need cleanup
+  }
+
+  /**
+   * Returns whether this loader supports hot-reloading functionality.
+   *
+   * @return true if the loader supports hot-reloading, false otherwise
+   */
+  default boolean supportsHotReloading() {
+    return false;
+  }
+
+  /**
+   * Returns a description of what type of agents this loader handles.
+   *
+   * @return A string description of the loader type
+   */
+  String getLoaderType();
+}

--- a/dev/src/main/java/com/google/adk/web/AgentYamlHotLoader.java
+++ b/dev/src/main/java/com/google/adk/web/AgentYamlHotLoader.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.web;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.agents.ConfigAgentUtils;
+import com.google.adk.web.config.AgentLoadingProperties;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Hot-loading service for YAML-based agents. Monitors the configured source directory for
+ * `root_agent.yaml` files and automatically reloads agents when the files change.
+ *
+ * <p>This service complements the {@link AgentCompilerLoader} by providing hot-reloading
+ * capabilities for YAML-configured agents without requiring compilation.
+ *
+ * <p>Hot-reloading can be disabled for production environments by setting
+ * adk.agent.hotReloadingEnabled=false
+ *
+ * <p>TODO: Config agent features are not yet ready for public use.
+ */
+@Service
+public class AgentYamlHotLoader implements AgentLoader {
+  private static final Logger logger = LoggerFactory.getLogger(AgentYamlHotLoader.class);
+  private static final String YAML_CONFIG_FILENAME = "root_agent.yaml";
+
+  private final boolean hotReloadingEnabled;
+  private final AgentLoadingProperties properties;
+  private final Map<String, BaseAgent> agentRegistry;
+  private final AdkWebServer.RunnerService runnerService;
+  private final Map<Path, Long> watchedFiles = new ConcurrentHashMap<>();
+  private final Map<Path, String> pathToAgentName = new ConcurrentHashMap<>();
+  private final ScheduledExecutorService fileWatcher = Executors.newSingleThreadScheduledExecutor();
+  private volatile boolean started = false;
+
+  /**
+   * Creates a new AgentYamlHotLoader.
+   *
+   * @param properties Configuration properties for agent loading
+   * @param agentRegistry The shared agent registry to update when agents are loaded/reloaded
+   * @param runnerService The runner service for cache invalidation
+   * @param hotReloadingEnabled Controls whether hot-reloading is enabled
+   */
+  public AgentYamlHotLoader(
+      AgentLoadingProperties properties,
+      Map<String, BaseAgent> agentRegistry,
+      AdkWebServer.RunnerService runnerService,
+      @Value("${adk.agent.hotReloadingEnabled:true}") boolean hotReloadingEnabled) {
+    this.properties = properties;
+    this.agentRegistry = agentRegistry;
+    this.runnerService = runnerService;
+    this.hotReloadingEnabled = hotReloadingEnabled;
+  }
+
+  @Override
+  public String getLoaderType() {
+    return hotReloadingEnabled ? "YAML Agents (Hot-Reloading)" : "YAML Agents (Static)";
+  }
+
+  @Override
+  public boolean supportsHotReloading() {
+    return hotReloadingEnabled;
+  }
+
+  @Override
+  public Map<String, BaseAgent> loadAgents() throws IOException {
+    if (properties.getSourceDir() == null || properties.getSourceDir().isEmpty()) {
+      logger.info("Agent source directory not configured. YAML loader will not load any agents.");
+      return new HashMap<>();
+    }
+
+    Path sourceDir = Paths.get(properties.getSourceDir());
+    if (!Files.isDirectory(sourceDir)) {
+      logger.warn(
+          "Agent source directory does not exist: {}. YAML loader will not load any agents.",
+          sourceDir);
+      return new HashMap<>();
+    }
+
+    logger.info("Initial scan for YAML agents in: {}", sourceDir);
+    Map<String, BaseAgent> loadedAgents = new HashMap<>();
+
+    try (Stream<Path> entries = Files.list(sourceDir)) {
+      for (Path agentDir : entries.collect(java.util.stream.Collectors.toList())) {
+        if (Files.isDirectory(agentDir)) {
+          Path yamlConfigPath = agentDir.resolve(YAML_CONFIG_FILENAME);
+          if (Files.exists(yamlConfigPath) && Files.isRegularFile(yamlConfigPath)) {
+            try {
+              logger.info("Loading YAML agent from: {}", yamlConfigPath);
+              BaseAgent agent = ConfigAgentUtils.fromConfig(yamlConfigPath.toString());
+              if (loadedAgents.containsKey(agent.name())) {
+                logger.warn(
+                    "Duplicate agent name '{}' found in {}. Overwriting.",
+                    agent.name(),
+                    yamlConfigPath);
+              }
+              loadedAgents.put(agent.name(), agent);
+              logger.info(
+                  "Successfully loaded YAML agent '{}' from: {}", agent.name(), yamlConfigPath);
+            } catch (Exception e) {
+              logger.error("Failed to load YAML agent from: {}", yamlConfigPath, e);
+            }
+          }
+        }
+      }
+    }
+
+    logger.info("Initial YAML agent scan complete. Loaded {} agents.", loadedAgents.size());
+    return loadedAgents;
+  }
+
+  /**
+   * Starts the hot-loading service. Sets up file watching. Initial loading should be done via
+   * {@link #loadAgents()}.
+   *
+   * @throws IOException if there's an error accessing the source directory
+   */
+  public synchronized void start() throws IOException {
+    if (!hotReloadingEnabled) {
+      logger.info(
+          "Hot-reloading is disabled (adk.agent.hotReloadingEnabled=false). YAML agents will be"
+              + " loaded once at startup and will not be monitored for changes.");
+      return;
+    }
+
+    if (started) {
+      logger.warn("AgentYamlHotLoader is already started");
+      return;
+    }
+
+    if (properties.getSourceDir() == null || properties.getSourceDir().isEmpty()) {
+      logger.info("Agent source directory not configured. YAML hot-loader will not start.");
+      return;
+    }
+
+    Path sourceDir = Paths.get(properties.getSourceDir());
+    if (!Files.isDirectory(sourceDir)) {
+      logger.warn(
+          "Agent source directory does not exist: {}. YAML hot-loader will not start.", sourceDir);
+      return;
+    }
+
+    logger.info("Starting AgentYamlHotLoader file watcher for directory: {}", sourceDir);
+
+    watchedFiles.clear();
+    pathToAgentName.clear();
+
+    // Look for agent directories (immediate subdirectories only)
+    try (Stream<Path> entries = Files.list(sourceDir)) {
+      entries
+          .filter(Files::isDirectory)
+          .forEach(
+              agentDir -> {
+                Path yamlConfigPath = agentDir.resolve(YAML_CONFIG_FILENAME);
+                if (Files.exists(yamlConfigPath) && Files.isRegularFile(yamlConfigPath)) {
+                  try {
+                    BaseAgent agent = ConfigAgentUtils.fromConfig(yamlConfigPath.toString());
+                    watchedFiles.put(yamlConfigPath, getLastModified(yamlConfigPath));
+                    pathToAgentName.put(yamlConfigPath, agent.name());
+                    logger.debug("Watching file: {} for agent: {}", yamlConfigPath, agent.name());
+                  } catch (Exception e) {
+                    logger.error(
+                        "Failed to read agent name from YAML for watcher setup: {}",
+                        yamlConfigPath,
+                        e);
+                  }
+                }
+              });
+    }
+
+    fileWatcher.scheduleAtFixedRate(this::checkForChanges, 2, 2, TimeUnit.SECONDS);
+    started = true;
+
+    Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
+
+    logger.info(
+        "AgentYamlHotLoader file watcher started successfully. Watching {} YAML files.",
+        watchedFiles.size());
+  }
+
+  /** Stops the hot-loading service. */
+  public synchronized void stop() {
+    if (!started) {
+      return;
+    }
+
+    logger.info("Stopping AgentYamlHotLoader...");
+    fileWatcher.shutdown();
+    try {
+      if (!fileWatcher.awaitTermination(5, TimeUnit.SECONDS)) {
+        fileWatcher.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      fileWatcher.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+    started = false;
+    logger.info("AgentYamlHotLoader stopped.");
+  }
+
+  /**
+   * Returns the current state of watched files for debugging purposes.
+   *
+   * @return A map of watched file paths to their last modification times
+   */
+  public Map<Path, Long> getWatchedFiles() {
+    return new HashMap<>(watchedFiles);
+  }
+
+  /**
+   * Returns whether hot-reloading is currently enabled.
+   *
+   * @return true if hot-reloading is enabled, false otherwise
+   */
+  public boolean isHotReloadingEnabled() {
+    return hotReloadingEnabled;
+  }
+
+  /**
+   * Loads or reloads a YAML agent from the specified path into the agentRegistry.
+   *
+   * @param yamlConfigPath The path to the YAML configuration file
+   * @throws Exception if loading fails
+   */
+  private void loadOrReloadYamlAgentIntoRegistry(Path yamlConfigPath) throws Exception {
+    logger.debug("Loading/Reloading YAML agent from: {}", yamlConfigPath);
+
+    BaseAgent agent = ConfigAgentUtils.fromConfig(yamlConfigPath.toString());
+
+    String oldAgentName = pathToAgentName.get(yamlConfigPath);
+    if (oldAgentName != null && !oldAgentName.equals(agent.name())) {
+      agentRegistry.remove(oldAgentName);
+      runnerService.onAgentUpdated(oldAgentName);
+      logger.info(
+          "Removed old agent '{}' from registry due to name change in {}",
+          oldAgentName,
+          yamlConfigPath);
+    }
+
+    agentRegistry.put(agent.name(), agent);
+    pathToAgentName.put(yamlConfigPath, agent.name());
+    watchedFiles.put(yamlConfigPath, getLastModified(yamlConfigPath));
+
+    if (runnerService != null) {
+      runnerService.onAgentUpdated(agent.name());
+      logger.info("Invalidated Runner cache for reloaded agent: {}", agent.name());
+    }
+
+    logger.info(
+        "Successfully loaded/reloaded YAML agent '{}' into registry from: {}",
+        agent.name(),
+        yamlConfigPath);
+  }
+
+  /** Checks all watched files for changes and reloads them if necessary. */
+  private void checkForChanges() {
+    if (!hotReloadingEnabled) {
+      return;
+    }
+
+    scanForNewYamlFiles();
+
+    for (Map.Entry<Path, Long> entry : new HashMap<>(watchedFiles).entrySet()) {
+      Path configPath = entry.getKey();
+      Long lastKnownModified = entry.getValue();
+
+      try {
+        if (!Files.exists(configPath)) {
+          handleFileDeleted(configPath);
+          continue;
+        }
+
+        long currentModified = getLastModified(configPath);
+        if (currentModified > lastKnownModified) {
+          logger.info("Detected change in YAML config: {}", configPath);
+          try {
+            loadOrReloadYamlAgentIntoRegistry(configPath);
+          } catch (Exception e) {
+            logger.error("Failed to reload YAML agent from: {}", configPath, e);
+          }
+        }
+      } catch (Exception e) {
+        logger.error("Error checking file for changes: {}", configPath, e);
+      }
+    }
+  }
+
+  /** Scans the source directory for any new root_agent.yaml files that are not being watched. */
+  private void scanForNewYamlFiles() {
+    Path sourceDir = Paths.get(properties.getSourceDir());
+    if (!Files.isDirectory(sourceDir)) {
+      return;
+    }
+
+    try (Stream<Path> entries = Files.list(sourceDir)) {
+      entries
+          .filter(Files::isDirectory)
+          .forEach(
+              agentDir -> {
+                Path yamlConfigPath = agentDir.resolve(YAML_CONFIG_FILENAME);
+                if (Files.exists(yamlConfigPath)
+                    && Files.isRegularFile(yamlConfigPath)
+                    && !watchedFiles.containsKey(yamlConfigPath)) {
+                  logger.info("Detected new YAML config file: {}", yamlConfigPath);
+                  try {
+                    loadOrReloadYamlAgentIntoRegistry(yamlConfigPath);
+                  } catch (Exception e) {
+                    logger.error("Failed to load new YAML agent from: {}", yamlConfigPath, e);
+                  }
+                }
+              });
+    } catch (IOException e) {
+      logger.error("Error scanning for new YAML files in: {}", sourceDir, e);
+    }
+  }
+
+  /**
+   * Handles the deletion of a watched YAML file.
+   *
+   * @param deletedPath The path of the deleted file
+   */
+  private void handleFileDeleted(Path deletedPath) {
+    logger.info("YAML config file deleted: {}", deletedPath);
+
+    watchedFiles.remove(deletedPath);
+    String agentName = pathToAgentName.remove(deletedPath);
+
+    if (agentName != null) {
+      agentRegistry.remove(agentName);
+      logger.info("Removed agent '{}' from registry due to deleted config file", agentName);
+      runnerService.onAgentUpdated(agentName);
+    }
+  }
+
+  /**
+   * Gets the last modified time of a file, handling potential I/O errors.
+   *
+   * @param path The file path
+   * @return The last modified time in milliseconds, or 0 if there's an error
+   */
+  private long getLastModified(Path path) {
+    try {
+      return Files.getLastModifiedTime(path).toMillis();
+    } catch (IOException e) {
+      logger.warn("Could not get last modified time for: {}", path, e);
+      return 0;
+    }
+  }
+}


### PR DESCRIPTION
This commit adds support for loading agents from YAML files. Agents can now be defined with a YAML configuration file, which is more human-friendly than code.

PiperOrigin-RevId: 791857223