### PR TITLE
refactor: Renames `AgentProvider` to `AgentLoader` and renames `getAg…

### DIFF
--- a/maven_plugin/examples/simple-agent/README.md
+++ b/maven_plugin/examples/simple-agent/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to create and run custom ADK agents using the Mave
 
 ## What's Included
 
-- **SimpleAgentProvider**: An implementation of `AgentProvider` that creates three example agents:
+- **SimpleAgentLoader**: An implementation of `AgentLoader` that creates three example agents:
   - `chat_assistant`: A friendly general-purpose assistant
   - `search_agent`: An agent with Google Search capabilities
   - `code_helper`: A coding assistant
@@ -12,13 +12,15 @@ This example demonstrates how to create and run custom ADK agents using the Mave
 ## How to Run
 
 1. **Compile the project:**
+
    ```bash
    mvn compile
    ```
 
 2. **Start the ADK Web Server:**
+
    ```bash
-   mvn google-adk:web -Dagents=com.example.SimpleAgentProvider.INSTANCE
+   mvn google-adk:web -Dagents=com.example.SimpleAgentLoader.INSTANCE
    ```
 
 3. **Open your browser:**
@@ -31,7 +33,7 @@ This example demonstrates how to create and run custom ADK agents using the Mave
 
 ## Customizing
 
-You can modify `SimpleAgentProvider.java` to:
+You can modify `SimpleAgentLoader.java` to:
 - Add more agents
 - Change agent instructions
 - Add different tools
@@ -41,6 +43,7 @@ You can modify `SimpleAgentProvider.java` to:
 Example modifications:
 
 ### Add a New Agent
+
 ```java
 private BaseAgent createMathTutor() {
   return LlmAgent.builder()
@@ -54,7 +57,8 @@ private BaseAgent createMathTutor() {
 }
 ```
 
-Then add it to the `listAgents()` method and `getAgent()` switch statement:
+Then add it to the `listAgents()` method and `loadAgent()` switch statement:
+
 ```java
 @Override
 @Nonnull
@@ -63,7 +67,7 @@ public ImmutableList<String> listAgents() {
 }
 
 @Override
-public BaseAgent getAgent(String name) {
+public BaseAgent loadAgent(String name) {
   switch (name) {
     case "chat_assistant":
       return createChatAssistant();
@@ -80,8 +84,9 @@ public BaseAgent getAgent(String name) {
 ```
 
 ### Configure Different Ports
+
 ```bash
-mvn google-adk:web -Dagents=com.example.SimpleAgentProvider.INSTANCE -Dport=9090
+mvn google-adk:web -Dagents=com.example.SimpleAgentLoader.INSTANCE -Dport=9090
 ```
 
 ## Next Steps

--- a/maven_plugin/examples/simple-agent/src/main/java/com/example/SimpleAgentLoader.java
+++ b/maven_plugin/examples/simple-agent/src/main/java/com/example/SimpleAgentLoader.java
@@ -18,7 +18,7 @@ package com.example;
 
 import com.google.adk.agents.BaseAgent;
 import com.google.adk.agents.LlmAgent;
-import com.google.adk.maven.AgentProvider;
+import com.google.adk.maven.AgentLoader;
 import com.google.adk.tools.GoogleSearchTool;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -28,15 +28,15 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
-/** Example AgentProvider that creates simple agents for demonstration. */
+/** Example AgentLoader that creates simple agents for demonstration. */
 @ThreadSafe
-public class SimpleAgentProvider implements AgentProvider {
+public class SimpleAgentLoader implements AgentLoader {
 
-  public static final SimpleAgentProvider INSTANCE = new SimpleAgentProvider();
+  public static final SimpleAgentLoader INSTANCE = new SimpleAgentLoader();
 
   private final ImmutableMap<String, Supplier<BaseAgent>> agentSuppliers;
 
-  public SimpleAgentProvider() {
+  public SimpleAgentLoader() {
     this.agentSuppliers =
         ImmutableMap.of(
             "chat_assistant", Suppliers.memoize(this::createChatAssistant),
@@ -51,7 +51,7 @@ public class SimpleAgentProvider implements AgentProvider {
   }
 
   @Override
-  public BaseAgent getAgent(String name) {
+  public BaseAgent loadAgent(String name) {
     Supplier<BaseAgent> supplier = agentSuppliers.get(name);
     if (supplier == null) {
       throw new NoSuchElementException("Agent not found: " + name);

--- a/maven_plugin/src/main/java/com/google/adk/maven/AgentLoader.java
+++ b/maven_plugin/src/main/java/com/google/adk/maven/AgentLoader.java
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Interface for providing agents to the ADK Web Server.
+ * Interface for loading agents to the ADK Web Server.
  *
  * <p>Users implement this interface to register their agents with ADK Web Server.
  *
@@ -30,14 +30,14 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>Example usage:
  *
  * <pre>{@code
- * public class MyAgentProvider implements AgentProvider {
+ * public class MyAgentLoader implements AgentLoader {
  *   @Override
  *   public ImmutableList<String> listAgents() {
  *     return ImmutableList.of("chat_bot", "code_assistant");
  *   }
  *
  *   @Override
- *   public BaseAgent getAgent(String name) {
+ *   public BaseAgent loadAgent(String name) {
  *     switch (name) {
  *       case "chat_bot": return createChatBot();
  *       case "code_assistant": return createCodeAssistant();
@@ -50,13 +50,13 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>Then use with Maven plugin:
  *
  * <pre>{@code
- * mvn google-adk:web -Dagents=com.acme.MyAgentProvider
+ * mvn google-adk:web -Dagents=com.acme.MyAgentLoader
  * }</pre>
  *
  * TODO: Add config-based agent registration in the future.
  */
 @ThreadSafe
-public interface AgentProvider {
+public interface AgentLoader {
 
   /**
    * Returns a list of available agent names.
@@ -68,12 +68,12 @@ public interface AgentProvider {
   ImmutableList<String> listAgents();
 
   /**
-   * Returns the BaseAgent instance for the specified agent name.
+   * Loads the BaseAgent instance for the specified agent name.
    *
-   * @param name the name of the agent to retrieve
+   * @param name the name of the agent to load
    * @return BaseAgent instance for the given name
    * @throws java.util.NoSuchElementException if the agent doesn't exist
    * @throws IllegalStateException if the agent exists but fails to load
    */
-  BaseAgent getAgent(String name);
+  BaseAgent loadAgent(String name);
 }


### PR DESCRIPTION
…ent` to `loadAgent`

This is consistent with the interface in python.
https://github.com/google/adk-python/blob/main/src/google/adk/cli/utils/agent_loader.py

PiperOrigin-RevId: 793964389