### PR TITLE
feat: add configurable live-session inactivity nudges

### DIFF
--- a/core/src/main/java/com/google/adk/agents/LiveRequestQueue.java
+++ b/core/src/main/java/com/google/adk/agents/LiveRequestQueue.java
@@ -19,12 +19,23 @@ package com.google.adk.agents;
 import com.google.genai.types.Blob;
 import com.google.genai.types.Content;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.processors.FlowableProcessor;
 import io.reactivex.rxjava3.processors.MulticastProcessor;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /** A queue of live requests to be sent to the model. */
 public final class LiveRequestQueue {
   private final FlowableProcessor<LiveRequest> processor;
+  private final Object activityLock = new Object();
+  private final List<InactivityWatcher> inactivityWatchers = new ArrayList<>();
+  private boolean closed;
 
   public LiveRequestQueue() {
     MulticastProcessor<LiveRequest> processor = MulticastProcessor.<LiveRequest>create();
@@ -33,19 +44,85 @@ public final class LiveRequestQueue {
   }
 
   public void close() {
-    processor.onNext(LiveRequest.builder().close(true).build());
-    processor.onComplete();
+    send(LiveRequest.builder().close(true).build());
   }
 
   public void content(Content content) {
-    processor.onNext(LiveRequest.builder().content(content).build());
+    send(LiveRequest.builder().content(content).build());
   }
 
   public void realtime(Blob blob) {
-    processor.onNext(LiveRequest.builder().blob(blob).build());
+    send(LiveRequest.builder().blob(blob).build());
   }
 
   public void send(LiveRequest request) {
+    Objects.requireNonNull(request, "request cannot be null");
+    synchronized (activityLock) {
+      if (closed) {
+        return;
+      }
+      if (request.shouldClose()) {
+        closed = true;
+        inactivityWatchers.forEach(InactivityWatcher::disposeLocked);
+        inactivityWatchers.clear();
+      } else {
+        inactivityWatchers.forEach(InactivityWatcher::recordUserActivityLocked);
+      }
+      sendInternal(request);
+    }
+  }
+
+  /**
+   * Records an assistant response as session activity.
+   *
+   * <p>Assistant activity moves an armed inactivity deadline so users get the full configured time
+   * to respond after the assistant finishes. It does not rearm a watcher that has already emitted a
+   * nudge; only new user activity does that.
+   */
+  public void recordAssistantActivity() {
+    synchronized (activityLock) {
+      if (!closed) {
+        inactivityWatchers.forEach(InactivityWatcher::recordAssistantActivityLocked);
+      }
+    }
+  }
+
+  /**
+   * Sends backend content after each period of inactivity while this live queue remains open.
+   *
+   * <p>The first deadline starts immediately. User text/audio/video resets and rearms it. Assistant
+   * output moves an armed deadline. After the content is sent, the watcher remains disarmed until
+   * the next user request, preventing repeated nudges during one idle period.
+   */
+  public Disposable watchForInactivity(
+      Duration timeout, Scheduler scheduler, Supplier<Content> contentSupplier) {
+    Objects.requireNonNull(timeout, "timeout cannot be null");
+    Objects.requireNonNull(scheduler, "scheduler cannot be null");
+    Objects.requireNonNull(contentSupplier, "contentSupplier cannot be null");
+    if (timeout.isZero() || timeout.isNegative()) {
+      throw new IllegalArgumentException("timeout must be positive");
+    }
+
+    InactivityWatcher watcher = new InactivityWatcher(timeout, scheduler, contentSupplier);
+    synchronized (activityLock) {
+      if (closed) {
+        return Disposable.disposed();
+      }
+      inactivityWatchers.add(watcher);
+      watcher.recordUserActivityLocked();
+    }
+    return Disposable.fromRunnable(() -> removeWatcher(watcher));
+  }
+
+  private void removeWatcher(InactivityWatcher watcher) {
+    synchronized (activityLock) {
+      if (inactivityWatchers.remove(watcher)) {
+        watcher.disposeLocked();
+      }
+    }
+  }
+
+  private void sendInternal(LiveRequest request) {
     processor.onNext(request);
     if (request.shouldClose()) {
       processor.onComplete();
@@ -54,5 +131,63 @@ public final class LiveRequestQueue {
 
   public Flowable<LiveRequest> get() {
     return processor;
+  }
+
+  private final class InactivityWatcher {
+    private final Duration timeout;
+    private final Scheduler scheduler;
+    private final Supplier<Content> contentSupplier;
+    private Disposable scheduledTask = Disposable.disposed();
+    private long generation;
+    private boolean armed;
+    private boolean disposed;
+
+    private InactivityWatcher(
+        Duration timeout, Scheduler scheduler, Supplier<Content> contentSupplier) {
+      this.timeout = timeout;
+      this.scheduler = scheduler;
+      this.contentSupplier = contentSupplier;
+    }
+
+    private void recordUserActivityLocked() {
+      armed = true;
+      scheduleLocked();
+    }
+
+    private void recordAssistantActivityLocked() {
+      if (armed) {
+        scheduleLocked();
+      }
+    }
+
+    private void scheduleLocked() {
+      if (disposed) {
+        return;
+      }
+      scheduledTask.dispose();
+      long scheduledGeneration = ++generation;
+      scheduledTask =
+          scheduler.scheduleDirect(
+              () -> emitIfStillInactive(scheduledGeneration),
+              timeout.toNanos(),
+              TimeUnit.NANOSECONDS);
+    }
+
+    private void emitIfStillInactive(long scheduledGeneration) {
+      synchronized (activityLock) {
+        if (closed || disposed || !armed || generation != scheduledGeneration) {
+          return;
+        }
+        armed = false;
+        sendInternal(LiveRequest.builder().content(contentSupplier.get()).build());
+      }
+    }
+
+    private void disposeLocked() {
+      disposed = true;
+      armed = false;
+      generation++;
+      scheduledTask.dispose();
+    }
   }
 }

--- a/core/src/main/java/com/google/adk/apps/App.java
+++ b/core/src/main/java/com/google/adk/apps/App.java
@@ -23,6 +23,7 @@ import com.google.adk.summarizer.EventsCompactionConfig;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 
@@ -44,6 +45,7 @@ public class App {
   private final @Nullable EventsCompactionConfig eventsCompactionConfig;
   private final @Nullable ContextCacheConfig contextCacheConfig;
   private final @Nullable ResumabilityConfig resumabilityConfig;
+  private final InactivityNudgeConfig inactivityNudgeConfig;
 
   private App(
       String name,
@@ -51,13 +53,15 @@ public class App {
       List<? extends Plugin> plugins,
       @Nullable EventsCompactionConfig eventsCompactionConfig,
       @Nullable ContextCacheConfig contextCacheConfig,
-      @Nullable ResumabilityConfig resumabilityConfig) {
+      @Nullable ResumabilityConfig resumabilityConfig,
+      InactivityNudgeConfig inactivityNudgeConfig) {
     this.name = name;
     this.rootAgent = rootAgent;
     this.plugins = ImmutableList.copyOf(plugins);
     this.eventsCompactionConfig = eventsCompactionConfig;
     this.contextCacheConfig = contextCacheConfig;
     this.resumabilityConfig = resumabilityConfig;
+    this.inactivityNudgeConfig = inactivityNudgeConfig;
   }
 
   public String name() {
@@ -86,6 +90,11 @@ public class App {
     return resumabilityConfig;
   }
 
+  /** Returns the policy for inactivity nudges in connected live sessions. */
+  public InactivityNudgeConfig inactivityNudgeConfig() {
+    return inactivityNudgeConfig;
+  }
+
   /** Builder for {@link App}. */
   public static class Builder {
     private String name;
@@ -94,6 +103,7 @@ public class App {
     @Nullable private EventsCompactionConfig eventsCompactionConfig;
     @Nullable private ContextCacheConfig contextCacheConfig;
     private @Nullable ResumabilityConfig resumabilityConfig;
+    private InactivityNudgeConfig inactivityNudgeConfig = InactivityNudgeConfig.disabled();
 
     @CanIgnoreReturnValue
     public Builder name(String name) {
@@ -131,6 +141,14 @@ public class App {
       return this;
     }
 
+    /** Sets the application-wide policy for inactivity nudges in connected live sessions. */
+    @CanIgnoreReturnValue
+    public Builder inactivityNudgeConfig(InactivityNudgeConfig inactivityNudgeConfig) {
+      this.inactivityNudgeConfig =
+          Objects.requireNonNull(inactivityNudgeConfig, "inactivityNudgeConfig cannot be null");
+      return this;
+    }
+
     /**
      * Sets the app resumability config.
      *
@@ -153,7 +171,13 @@ public class App {
       }
       validateAppName(name);
       return new App(
-          name, rootAgent, plugins, eventsCompactionConfig, contextCacheConfig, resumabilityConfig);
+          name,
+          rootAgent,
+          plugins,
+          eventsCompactionConfig,
+          contextCacheConfig,
+          resumabilityConfig,
+          inactivityNudgeConfig);
     }
   }
 

--- a/core/src/main/java/com/google/adk/apps/InactivityNudgeConfig.java
+++ b/core/src/main/java/com/google/adk/apps/InactivityNudgeConfig.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.apps;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/** Application-wide policy for nudging an inactive user while a live session remains connected. */
+public record InactivityNudgeConfig(
+    boolean enabled,
+    Duration inactivityTimeout,
+    String defaultLocale,
+    String localeStateKey,
+    ImmutableMap<String, String> localizedMessages) {
+
+  private static final Duration DEFAULT_INACTIVITY_TIMEOUT = Duration.ofSeconds(5);
+  private static final String DEFAULT_LOCALE = "en";
+  private static final String DEFAULT_LOCALE_STATE_KEY = "locale";
+  private static final ImmutableMap<String, String> DEFAULT_MESSAGES =
+      ImmutableMap.of(DEFAULT_LOCALE, "Hey, are you there?");
+
+  public InactivityNudgeConfig {
+    Objects.requireNonNull(inactivityTimeout, "inactivityTimeout cannot be null");
+    Objects.requireNonNull(defaultLocale, "defaultLocale cannot be null");
+    Objects.requireNonNull(localeStateKey, "localeStateKey cannot be null");
+    Objects.requireNonNull(localizedMessages, "localizedMessages cannot be null");
+    if (inactivityTimeout.isZero() || inactivityTimeout.isNegative()) {
+      throw new IllegalArgumentException("inactivityTimeout must be positive");
+    }
+    if (defaultLocale.isBlank()) {
+      throw new IllegalArgumentException("defaultLocale cannot be blank");
+    }
+    if (localeStateKey.isBlank()) {
+      throw new IllegalArgumentException("localeStateKey cannot be blank");
+    }
+
+    ImmutableMap.Builder<String, String> normalizedMessages = ImmutableMap.builder();
+    localizedMessages.forEach(
+        (locale, message) -> {
+          if (locale == null || locale.isBlank()) {
+            throw new IllegalArgumentException("Message locale cannot be null or blank");
+          }
+          if (message == null || message.isBlank()) {
+            throw new IllegalArgumentException("Nudge message cannot be null or blank");
+          }
+          normalizedMessages.put(normalizeLocale(locale), message);
+        });
+    localizedMessages = normalizedMessages.buildOrThrow();
+
+    String normalizedDefaultLocale = normalizeLocale(defaultLocale);
+    if (!localizedMessages.containsKey(normalizedDefaultLocale)) {
+      throw new IllegalArgumentException(
+          "localizedMessages must contain the default locale: " + defaultLocale);
+    }
+    defaultLocale = normalizedDefaultLocale;
+  }
+
+  /** Returns a disabled policy with otherwise usable defaults. */
+  public static InactivityNudgeConfig disabled() {
+    return builder().build();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Resolves an exact locale, then its language, and finally the configured default locale. */
+  public String messageForLocale(String locale) {
+    String normalizedLocale =
+        locale == null || locale.isBlank() ? defaultLocale : normalizeLocale(locale);
+    String exactMessage = localizedMessages.get(normalizedLocale);
+    if (exactMessage != null) {
+      return exactMessage;
+    }
+
+    int regionSeparator = normalizedLocale.indexOf('-');
+    if (regionSeparator > 0) {
+      String languageMessage =
+          localizedMessages.get(normalizedLocale.substring(0, regionSeparator));
+      if (languageMessage != null) {
+        return languageMessage;
+      }
+    }
+    return localizedMessages.get(defaultLocale);
+  }
+
+  private static String normalizeLocale(String locale) {
+    return locale.trim().replace('_', '-').toLowerCase(Locale.ROOT);
+  }
+
+  /** Builder for {@link InactivityNudgeConfig}. */
+  public static final class Builder {
+    private boolean enabled;
+    private Duration inactivityTimeout = DEFAULT_INACTIVITY_TIMEOUT;
+    private String defaultLocale = DEFAULT_LOCALE;
+    private String localeStateKey = DEFAULT_LOCALE_STATE_KEY;
+    private Map<String, String> localizedMessages = DEFAULT_MESSAGES;
+
+    private Builder() {}
+
+    @CanIgnoreReturnValue
+    public Builder enabled(boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder inactivityTimeout(Duration inactivityTimeout) {
+      this.inactivityTimeout = inactivityTimeout;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder defaultLocale(String defaultLocale) {
+      this.defaultLocale = defaultLocale;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder localeStateKey(String localeStateKey) {
+      this.localeStateKey = localeStateKey;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder localizedMessages(Map<String, String> localizedMessages) {
+      this.localizedMessages = localizedMessages;
+      return this;
+    }
+
+    public InactivityNudgeConfig build() {
+      return new InactivityNudgeConfig(
+          enabled,
+          inactivityTimeout,
+          defaultLocale,
+          localeStateKey,
+          ImmutableMap.copyOf(localizedMessages));
+    }
+  }
+}

--- a/core/src/main/java/com/google/adk/runner/Runner.java
+++ b/core/src/main/java/com/google/adk/runner/Runner.java
@@ -27,6 +27,7 @@ import com.google.adk.agents.LlmAgent;
 import com.google.adk.agents.RunConfig;
 import com.google.adk.agents.SequentialAgent;
 import com.google.adk.apps.App;
+import com.google.adk.apps.InactivityNudgeConfig;
 import com.google.adk.apps.ResumabilityConfig;
 import com.google.adk.artifacts.BaseArtifactService;
 import com.google.adk.artifacts.InMemoryArtifactService;
@@ -63,7 +64,10 @@ import io.opentelemetry.context.Context;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.CompletableSubject;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,6 +91,7 @@ public class Runner {
   @Nullable private final EventsCompactionConfig eventsCompactionConfig;
   @Nullable private final ContextCacheConfig contextCacheConfig;
   private final @Nullable ResumabilityConfig resumabilityConfig;
+  private final InactivityNudgeConfig inactivityNudgeConfig;
   private final ConcurrentMap<String, Completable> activeSessionCompletables =
       new MapMaker().weakValues().makeMap();
 
@@ -99,6 +104,7 @@ public class Runner {
     private BaseSessionService sessionService = new InMemorySessionService();
     @Nullable private BaseMemoryService memoryService = null;
     private List<? extends Plugin> plugins = ImmutableList.of();
+    private List<? extends Plugin> additionalPlugins = ImmutableList.of();
 
     @CanIgnoreReturnValue
     public Builder app(App app) {
@@ -153,6 +159,20 @@ public class Runner {
       return this;
     }
 
+    /** Adds plugins to those already configured by an {@link App}. */
+    @CanIgnoreReturnValue
+    public Builder additionalPlugins(List<? extends Plugin> additionalPlugins) {
+      this.additionalPlugins = ImmutableList.copyOf(additionalPlugins);
+      return this;
+    }
+
+    /** Adds plugins to those already configured by an {@link App}. */
+    @CanIgnoreReturnValue
+    public Builder additionalPlugins(Plugin... additionalPlugins) {
+      this.additionalPlugins = ImmutableList.copyOf(additionalPlugins);
+      return this;
+    }
+
     public Runner build() {
       BaseAgent buildAgent;
       String buildAppName;
@@ -160,6 +180,7 @@ public class Runner {
       EventsCompactionConfig buildEventsCompactionConfig;
       ContextCacheConfig buildContextCacheConfig;
       ResumabilityConfig buildResumabilityConfig;
+      InactivityNudgeConfig buildInactivityNudgeConfig;
 
       if (this.app != null) {
         if (this.agent != null) {
@@ -169,18 +190,28 @@ public class Runner {
           throw new IllegalStateException("plugins() cannot be called when app() is called.");
         }
         buildAgent = this.app.rootAgent();
-        buildPlugins = this.app.plugins();
+        buildPlugins =
+            ImmutableList.<Plugin>builder()
+                .addAll(this.app.plugins())
+                .addAll(this.additionalPlugins)
+                .build();
         buildAppName = this.appName == null ? this.app.name() : this.appName;
         buildEventsCompactionConfig = this.app.eventsCompactionConfig();
         buildContextCacheConfig = this.app.contextCacheConfig();
         buildResumabilityConfig = this.app.resumabilityConfig();
+        buildInactivityNudgeConfig = this.app.inactivityNudgeConfig();
       } else {
         buildAgent = this.agent;
         buildAppName = this.appName;
-        buildPlugins = this.plugins;
+        buildPlugins =
+            ImmutableList.<Plugin>builder()
+                .addAll(this.plugins)
+                .addAll(this.additionalPlugins)
+                .build();
         buildEventsCompactionConfig = null;
         buildContextCacheConfig = null;
         buildResumabilityConfig = null;
+        buildInactivityNudgeConfig = InactivityNudgeConfig.disabled();
       }
 
       if (buildAgent == null) {
@@ -204,7 +235,8 @@ public class Runner {
           buildPlugins,
           buildEventsCompactionConfig,
           buildContextCacheConfig,
-          buildResumabilityConfig);
+          buildResumabilityConfig,
+          buildInactivityNudgeConfig);
     }
   }
 
@@ -286,6 +318,30 @@ public class Runner {
       @Nullable EventsCompactionConfig eventsCompactionConfig,
       @Nullable ContextCacheConfig contextCacheConfig,
       @Nullable ResumabilityConfig resumabilityConfig) {
+    this(
+        agent,
+        appName,
+        artifactService,
+        sessionService,
+        memoryService,
+        plugins,
+        eventsCompactionConfig,
+        contextCacheConfig,
+        resumabilityConfig,
+        InactivityNudgeConfig.disabled());
+  }
+
+  private Runner(
+      BaseAgent agent,
+      String appName,
+      BaseArtifactService artifactService,
+      BaseSessionService sessionService,
+      @Nullable BaseMemoryService memoryService,
+      List<? extends Plugin> plugins,
+      @Nullable EventsCompactionConfig eventsCompactionConfig,
+      @Nullable ContextCacheConfig contextCacheConfig,
+      @Nullable ResumabilityConfig resumabilityConfig,
+      InactivityNudgeConfig inactivityNudgeConfig) {
     this.agent = agent;
     this.appName = appName;
     this.artifactService = artifactService;
@@ -295,6 +351,7 @@ public class Runner {
     this.eventsCompactionConfig = createEventsCompactionConfig(agent, eventsCompactionConfig);
     this.contextCacheConfig = contextCacheConfig;
     this.resumabilityConfig = resumabilityConfig;
+    this.inactivityNudgeConfig = inactivityNudgeConfig;
   }
 
   /**
@@ -334,6 +391,11 @@ public class Runner {
 
   public PluginManager pluginManager() {
     return this.pluginManager;
+  }
+
+  /** Returns the application-wide inactivity nudge policy. */
+  public InactivityNudgeConfig inactivityNudgeConfig() {
+    return this.inactivityNudgeConfig;
   }
 
   /** Closes all plugins, code executors, and releases any resources. */
@@ -778,6 +840,9 @@ public class Runner {
       Session session, @Nullable LiveRequestQueue liveRequestQueue, RunConfig runConfig) {
     return Flowable.defer(
         () -> {
+          Disposable inactivityNudgeWatcher =
+              scheduleInactivityNudge(
+                  session, liveRequestQueue, inactivityNudgeConfig, Schedulers.computation());
           Context capturedContext = Context.current();
           InvocationContext invocationContext =
               newInvocationContextForLive(session, liveRequestQueue, runConfig);
@@ -801,6 +866,12 @@ public class Runner {
                       updatedInvocationContext
                           .agent()
                           .runLive(updatedInvocationContext)
+                          .doOnNext(
+                              event -> {
+                                if (liveRequestQueue != null) {
+                                  liveRequestQueue.recordAssistantActivity();
+                                }
+                              })
                           .concatMapSingle(
                               event ->
                                   this.sessionService
@@ -830,8 +901,38 @@ public class Runner {
                         .onErrorComplete()
                         .subscribe();
                   })
-              .compose(Tracing.<Event>withContext(capturedContext));
+              .compose(Tracing.<Event>withContext(capturedContext))
+              .doFinally(inactivityNudgeWatcher::dispose);
         });
+  }
+
+  static Disposable scheduleInactivityNudge(
+      Session session,
+      @Nullable LiveRequestQueue liveRequestQueue,
+      InactivityNudgeConfig config,
+      Scheduler scheduler) {
+    if (!config.enabled() || liveRequestQueue == null) {
+      return Disposable.disposed();
+    }
+
+    return liveRequestQueue.watchForInactivity(
+        config.inactivityTimeout(), scheduler, () -> buildInactivityNudgeContent(session, config));
+  }
+
+  private static Content buildInactivityNudgeContent(
+      Session session, InactivityNudgeConfig config) {
+    Object configuredLocale = session.state().get(config.localeStateKey());
+    String locale = configuredLocale == null ? config.defaultLocale() : configuredLocale.toString();
+    String message = config.messageForLocale(locale);
+    return Content.builder()
+        .role("user")
+        .parts(
+            ImmutableList.of(
+                Part.fromText(
+                    "The user has been inactive. Check whether they are still there. Respond with"
+                        + " exactly this message and nothing else: "
+                        + message)))
+        .build();
   }
 
   /**

--- a/core/src/test/java/com/google/adk/apps/InactivityNudgeConfigTest.java
+++ b/core/src/test/java/com/google/adk/apps/InactivityNudgeConfigTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.apps;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
+import org.junit.Test;
+
+public final class InactivityNudgeConfigTest {
+
+  @Test
+  public void defaultsToDisabled() {
+    InactivityNudgeConfig config = InactivityNudgeConfig.disabled();
+
+    assertThat(config.enabled()).isFalse();
+    assertThat(config.inactivityTimeout()).isEqualTo(Duration.ofSeconds(5));
+    assertThat(config.messageForLocale("en-IN")).isEqualTo("Hey, are you there?");
+  }
+
+  @Test
+  public void resolvesExactLanguageAndDefaultLocales() {
+    InactivityNudgeConfig config =
+        InactivityNudgeConfig.builder()
+            .defaultLocale("en-IN")
+            .localizedMessages(
+                ImmutableMap.of(
+                    "en-IN", "Are you there?",
+                    "hi", "क्या आप वहाँ हैं?",
+                    "hi-IN", "क्या आप अभी भी वहाँ हैं?"))
+            .build();
+
+    assertThat(config.messageForLocale("hi_IN")).isEqualTo("क्या आप अभी भी वहाँ हैं?");
+    assertThat(config.messageForLocale("hi-NP")).isEqualTo("क्या आप वहाँ हैं?");
+    assertThat(config.messageForLocale("ta-IN")).isEqualTo("Are you there?");
+  }
+
+  @Test
+  public void rejectsNonPositiveTimeout() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> InactivityNudgeConfig.builder().inactivityTimeout(Duration.ZERO).build());
+  }
+
+  @Test
+  public void requiresMessageForDefaultLocale() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            InactivityNudgeConfig.builder()
+                .defaultLocale("hi")
+                .localizedMessages(ImmutableMap.of("en", "Hello"))
+                .build());
+  }
+}

--- a/core/src/test/java/com/google/adk/runner/InactivityNudgeRunnerTest.java
+++ b/core/src/test/java/com/google/adk/runner/InactivityNudgeRunnerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.runner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.adk.agents.LiveRequest;
+import com.google.adk.agents.LiveRequestQueue;
+import com.google.adk.agents.LlmAgent;
+import com.google.adk.apps.App;
+import com.google.adk.apps.InactivityNudgeConfig;
+import com.google.adk.events.Event;
+import com.google.adk.sessions.Session;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.Blob;
+import com.google.genai.types.Content;
+import com.google.genai.types.Part;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.TestScheduler;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import java.time.Duration;
+import org.junit.Test;
+
+public final class InactivityNudgeRunnerTest {
+
+  @Test
+  public void openingSilenceInjectsLocalizedNudgeAfterTimeout() {
+    Session session = newSession();
+    session.state().put("locale", "hi-IN");
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+    InactivityNudgeConfig config =
+        InactivityNudgeConfig.builder()
+            .enabled(true)
+            .inactivityTimeout(Duration.ofSeconds(4))
+            .defaultLocale("en")
+            .localizedMessages(
+                ImmutableMap.of("en", "Are you there?", "hi-IN", "क्या आप अभी भी वहाँ हैं?"))
+            .build();
+
+    Disposable watcher = Runner.scheduleInactivityNudge(session, queue, config, scheduler);
+    scheduler.advanceTimeBy(3, SECONDS);
+    requests.assertNoValues();
+
+    scheduler.advanceTimeBy(1, SECONDS);
+
+    requests.assertValueCount(1);
+    assertThat(requestText(requests.values().get(0))).contains("क्या आप अभी भी वहाँ हैं?");
+    watcher.dispose();
+  }
+
+  @Test
+  public void textActivityResetsDeadlineAndNudgeCanFireMidSession() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+    Runner.scheduleInactivityNudge(newSession(), queue, enabledConfig(), scheduler);
+
+    scheduler.advanceTimeBy(4, SECONDS);
+    queue.content(Content.fromParts(Part.fromText("Hello")));
+    scheduler.advanceTimeBy(4, SECONDS);
+    requests.assertValueCount(1);
+
+    scheduler.advanceTimeBy(1, SECONDS);
+
+    requests.assertValueCount(2);
+    assertThat(requestText(requests.values().get(1))).contains("Hey, are you there?");
+  }
+
+  @Test
+  public void audioActivityResetsDeadline() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+    Runner.scheduleInactivityNudge(newSession(), queue, enabledConfig(), scheduler);
+
+    scheduler.advanceTimeBy(4, SECONDS);
+    queue.realtime(Blob.builder().mimeType("audio/pcm").data(new byte[] {1, 2, 3}).build());
+    scheduler.advanceTimeBy(4, SECONDS);
+    requests.assertValueCount(1);
+
+    scheduler.advanceTimeBy(1, SECONDS);
+    requests.assertValueCount(2);
+  }
+
+  @Test
+  public void assistantOutputMovesDeadlineUntilResponseFinishes() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+    Runner.scheduleInactivityNudge(newSession(), queue, enabledConfig(), scheduler);
+
+    scheduler.advanceTimeBy(4, SECONDS);
+    queue.recordAssistantActivity();
+    scheduler.advanceTimeBy(4, SECONDS);
+    requests.assertNoValues();
+
+    scheduler.advanceTimeBy(1, SECONDS);
+    requests.assertValueCount(1);
+  }
+
+  @Test
+  public void existingSessionCanReceiveNudge() {
+    Session session = newSession();
+    session.events().add(Event.builder().id(Event.generateEventId()).author("agent").build());
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+
+    Runner.scheduleInactivityNudge(session, queue, enabledConfig(), scheduler);
+    scheduler.advanceTimeBy(5, SECONDS);
+
+    requests.assertValueCount(1);
+  }
+
+  @Test
+  public void nudgeFiresOncePerIdlePeriodAndRearmsAfterUserActivity() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+    Runner.scheduleInactivityNudge(newSession(), queue, enabledConfig(), scheduler);
+
+    scheduler.advanceTimeBy(20, SECONDS);
+    requests.assertValueCount(1);
+
+    queue.content(Content.fromParts(Part.fromText("Still here")));
+    scheduler.advanceTimeBy(5, SECONDS);
+
+    requests.assertValueCount(3);
+    assertThat(requestText(requests.values().get(1))).isEqualTo("Still here");
+    assertThat(requestText(requests.values().get(2))).contains("Hey, are you there?");
+  }
+
+  @Test
+  public void closeCancelsPendingNudge() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+    Runner.scheduleInactivityNudge(newSession(), queue, enabledConfig(), scheduler);
+
+    queue.close();
+    scheduler.advanceTimeBy(10, SECONDS);
+
+    requests.assertValueCount(1);
+    assertThat(requests.values().get(0).shouldClose()).isTrue();
+  }
+
+  @Test
+  public void disabledPolicyDoesNotScheduleNudge() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> requests = queue.get().test();
+    TestScheduler scheduler = new TestScheduler();
+
+    Runner.scheduleInactivityNudge(
+        newSession(), queue, InactivityNudgeConfig.disabled(), scheduler);
+    scheduler.advanceTimeBy(10, SECONDS);
+
+    requests.assertNoValues();
+  }
+
+  @Test
+  public void runnerUsesApplicationInactivityPolicy() {
+    InactivityNudgeConfig inactivityConfig = enabledConfig();
+    App app =
+        App.builder()
+            .name("app")
+            .rootAgent(LlmAgent.builder().name("agent").model("test-model").build())
+            .inactivityNudgeConfig(inactivityConfig)
+            .build();
+
+    Runner runner = Runner.builder().app(app).build();
+
+    assertThat(runner.inactivityNudgeConfig()).isEqualTo(inactivityConfig);
+  }
+
+  private static InactivityNudgeConfig enabledConfig() {
+    return InactivityNudgeConfig.builder()
+        .enabled(true)
+        .inactivityTimeout(Duration.ofSeconds(5))
+        .build();
+  }
+
+  private static Session newSession() {
+    return Session.builder("session").appName("app").userId("user").build();
+  }
+
+  private static String requestText(LiveRequest request) {
+    return request.content().orElseThrow().parts().orElseThrow().get(0).text().orElseThrow();
+  }
+}

--- a/dev/src/main/java/com/google/adk/web/AdkWebServer.java
+++ b/dev/src/main/java/com/google/adk/web/AdkWebServer.java
@@ -19,6 +19,7 @@ package com.google.adk.web;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.adk.JsonBaseModel;
 import com.google.adk.agents.BaseAgent;
+import com.google.adk.apps.App;
 import com.google.adk.artifacts.BaseArtifactService;
 import com.google.adk.artifacts.InMemoryArtifactService;
 import com.google.adk.artifacts.MapDbArtifactService;
@@ -220,5 +221,25 @@ public class AdkWebServer implements WebMvcConfigurer {
         });
 
     app.run(new String[0]);
+  }
+
+  /** Starts the web server with application definitions, preserving application-wide settings. */
+  public static void startApps(App... apps) {
+    System.setProperty("adk.agents.loader", "static");
+    System.setProperty(
+        "org.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE", String.valueOf(10 * 1024 * 1024));
+
+    SpringApplication springApplication = new SpringApplication(AdkWebServer.class);
+    springApplication.addInitializers(
+        new ApplicationContextInitializer<ConfigurableApplicationContext>() {
+          @Override
+          public void initialize(ConfigurableApplicationContext context) {
+            DefaultListableBeanFactory beanFactory =
+                (DefaultListableBeanFactory) context.getBeanFactory();
+            beanFactory.registerSingleton("agentLoader", AgentStaticLoader.fromApps(apps));
+          }
+        });
+
+    springApplication.run(new String[0]);
   }
 }

--- a/dev/src/main/java/com/google/adk/web/AgentLoader.java
+++ b/dev/src/main/java/com/google/adk/web/AgentLoader.java
@@ -17,7 +17,9 @@
 package com.google.adk.web;
 
 import com.google.adk.agents.BaseAgent;
+import com.google.adk.apps.App;
 import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -81,6 +83,16 @@ public interface AgentLoader {
    * @throws IllegalStateException if the agent exists but fails to load
    */
   BaseAgent loadAgent(String name);
+
+  /**
+   * Loads an application definition when the loader provides application-wide configuration.
+   *
+   * <p>The default remains empty for backwards compatibility with agent-only loaders. The web
+   * server falls back to {@link #loadAgent(String)} in that case.
+   */
+  default Optional<App> loadApp(String name) {
+    return Optional.empty();
+  }
 
   /**
    * Checks if an agent with the given name exists.

--- a/dev/src/main/java/com/google/adk/web/AgentStaticLoader.java
+++ b/dev/src/main/java/com/google/adk/web/AgentStaticLoader.java
@@ -22,9 +22,11 @@ import static java.util.Arrays.stream;
 import static java.util.function.Function.identity;
 
 import com.google.adk.agents.BaseAgent;
+import com.google.adk.apps.App;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 
 /**
@@ -40,9 +42,21 @@ import javax.annotation.Nonnull;
 public class AgentStaticLoader implements AgentLoader {
 
   private final ImmutableMap<String, BaseAgent> agents;
+  private final ImmutableMap<String, App> apps;
 
   public AgentStaticLoader(BaseAgent... agents) {
     this.agents = stream(agents).collect(toImmutableMap(BaseAgent::name, identity()));
+    this.apps = ImmutableMap.of();
+  }
+
+  private AgentStaticLoader(App... apps) {
+    this.apps = stream(apps).collect(toImmutableMap(App::name, identity()));
+    this.agents = this.apps.values().stream().collect(toImmutableMap(App::name, App::rootAgent));
+  }
+
+  /** Creates a static loader that preserves application-wide ADK configuration. */
+  public static AgentStaticLoader fromApps(App... apps) {
+    return new AgentStaticLoader(apps);
   }
 
   @Override
@@ -63,5 +77,10 @@ public class AgentStaticLoader implements AgentLoader {
     }
 
     return agent;
+  }
+
+  @Override
+  public Optional<App> loadApp(String name) {
+    return Optional.ofNullable(apps.get(name));
   }
 }

--- a/dev/src/main/java/com/google/adk/web/service/RunnerService.java
+++ b/dev/src/main/java/com/google/adk/web/service/RunnerService.java
@@ -17,6 +17,7 @@
 package com.google.adk.web.service;
 
 import com.google.adk.agents.BaseAgent;
+import com.google.adk.apps.App;
 import com.google.adk.artifacts.BaseArtifactService;
 import com.google.adk.memory.BaseMemoryService;
 import com.google.adk.plugins.BasePlugin;
@@ -26,6 +27,7 @@ import com.google.adk.web.AgentLoader;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,18 +75,23 @@ public class RunnerService {
         appName,
         key -> {
           try {
-            BaseAgent agent = agentProvider.loadAgent(key);
+            Optional<App> configuredApp = agentProvider.loadApp(key);
+            BaseAgent agent =
+                configuredApp.map(App::rootAgent).orElseGet(() -> agentProvider.loadAgent(key));
             log.info(
                 "RunnerService: Creating Runner for appName: {}, using agent definition: {}",
                 appName,
                 agent.name());
-            return Runner.builder()
-                .agent(agent)
-                .appName(appName)
+            Runner.Builder runnerBuilder = Runner.builder();
+            if (configuredApp.isPresent()) {
+              runnerBuilder.app(configuredApp.get()).additionalPlugins(this.extraPlugins);
+            } else {
+              runnerBuilder.agent(agent).appName(appName).plugins(this.extraPlugins);
+            }
+            return runnerBuilder
                 .artifactService(this.artifactService)
                 .sessionService(this.sessionService)
                 .memoryService(this.memoryService)
-                .plugins(this.extraPlugins)
                 .build();
           } catch (java.util.NoSuchElementException e) {
             log.error(

--- a/dev/src/test/java/com/google/adk/web/AgentStaticLoaderTest.java
+++ b/dev/src/test/java/com/google/adk/web/AgentStaticLoaderTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.adk.agents.BaseAgent;
 import com.google.adk.agents.LlmAgent;
+import com.google.adk.apps.App;
+import com.google.adk.apps.InactivityNudgeConfig;
 import org.junit.jupiter.api.Test;
 
 public class AgentStaticLoaderTest {
@@ -40,5 +42,25 @@ public class AgentStaticLoaderTest {
     assertTrue(staticLoader.listAgents().contains("test_agent"));
     assertEquals(testAgent, staticLoader.loadAgent("test_agent"));
     assertEquals("test_agent", staticLoader.loadAgent("test_agent").name());
+  }
+
+  @Test
+  public void appStaticLoaderPreservesApplicationConfiguration() {
+    BaseAgent rootAgent =
+        LlmAgent.builder().name("root_agent").model("gemini-2.5-flash-lite").build();
+    InactivityNudgeConfig inactivityConfig = InactivityNudgeConfig.builder().enabled(true).build();
+    App app =
+        App.builder()
+            .name("test_app")
+            .rootAgent(rootAgent)
+            .inactivityNudgeConfig(inactivityConfig)
+            .build();
+
+    AgentStaticLoader staticLoader = AgentStaticLoader.fromApps(app);
+
+    assertTrue(staticLoader.listAgents().contains("test_app"));
+    assertEquals(rootAgent, staticLoader.loadAgent("test_app"));
+    assertEquals(
+        inactivityConfig, staticLoader.loadApp("test_app").orElseThrow().inactivityNudgeConfig());
   }
 }


### PR DESCRIPTION
## Summary
- add application-only, opt-in inactivity nudge configuration
- detect opening and mid-session inactivity across live text, audio, and video input
- reset the deadline on user activity and assistant output
- emit one localized nudge per idle period and rearm after the next user input
- preserve application configuration through the ADK web server

The feature is disabled by default and legacy agent-only flows remain unchanged. A client must keep a live connection open; completed request/response HTTP calls cannot receive a later backend push.

## Testing
- `mvn -pl core clean test` — 1,850 tests passed, 0 failures/errors
- `mvn -pl dev -am -DskipTests compile`
- `mvn -pl dev -am -Dtest=AgentStaticLoaderTest -Dsurefire.failIfNoSpecifiedTests=false test`